### PR TITLE
Initial drop of tests for Travis CI

### DIFF
--- a/atomicapp/cli/main.py
+++ b/atomicapp/cli/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from atomicapp.run import Run
 from atomicapp.install import Install

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 
-echo "this is a void test suite..."
+export PYTHONPATH=`pwd`
+
+let failures=0
+
+cd tests
+for test in `ls test_*.sh`; do
+    if ./$test; then
+        echo "SUCCESS"
+    else
+        echo "FAILURE"
+        let failures+=1
+    fi
+done
+
+if [ "$failures" -eq "0" ]; then
+  exit 0
+else
+  exit 1
+fi
 
 #end.

--- a/tests/cached_nulecules/helloapache/.workdir/helloapache-app/artifacts/k8s/hello-apache-pod.json
+++ b/tests/cached_nulecules/helloapache/.workdir/helloapache-app/artifacts/k8s/hello-apache-pod.json
@@ -1,0 +1,25 @@
+{
+    "apiVersion": "v1beta3",
+    "kind": "Pod",
+    "metadata": {
+        "labels": {
+            "app": "helloapache"
+        },
+        "name": "helloapache"
+    },
+    "spec": {
+        "containers": [
+            {
+                "image": "centos/httpd",
+                "name": "helloapache",
+                "ports": [
+                    {
+                        "containerPort": 80,
+                        "hostPort": 80,
+                        "protocol": "TCP"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/cached_nulecules/helloapache/Dockerfile
+++ b/tests/cached_nulecules/helloapache/Dockerfile
@@ -1,0 +1,6 @@
+FROM projectatomic/atomicapp:0.1.1
+
+MAINTAINER Aaron Weitekamp <aweiteka@redhat.com>
+
+ADD /Nulecule /Dockerfile README.md /application-entity/
+ADD /artifacts /application-entity/artifacts

--- a/tests/cached_nulecules/helloapache/Nulecule
+++ b/tests/cached_nulecules/helloapache/Nulecule
@@ -1,0 +1,20 @@
+---
+specversion: 0.0.2
+id: helloapache-app
+
+metadata:
+  name: Hello Apache App
+  appversion: 0.0.1
+  description: Atomic app for deploying a really basic Apache HTTP server
+graph:
+  - name: helloapache-app
+    params:
+      - name: image
+        description: The webserver image
+        default: centos/httpd
+      - name: hostport
+        description: The host TCP port as the external endpoint
+        default: 80
+    artifacts:
+      kubernetes:
+        - file://artifacts/k8s/hello-apache-pod.json

--- a/tests/cached_nulecules/helloapache/README.md
+++ b/tests/cached_nulecules/helloapache/README.md
@@ -1,0 +1,56 @@
+This is an atomic application based on the nulecule specification. Kubernetes is currently the only supported provider. You'll need to run this from a workstation that has the atomic CLI and kubectl client that can connect to a kubernetes master.
+
+It's a single pod based on the centos/httpd image, but you can use your own.
+
+### Option 1: interactive
+
+Run the image. You will be prompted to override defaults
+```
+[sudo] atomic run projectatomic/helloapache
+```
+
+## Option 2: unattended
+
+1. Create file `answers.conf` with these contents:
+
+        [general]
+        provider = kubernetes
+
+        [helloapache-app]
+        image = centos/httpd # optional: choose a different image
+        hostport = 80        # optional: choose a different port to expose
+
+1. Run the application from the current working directory
+
+        $ [sudo] atomic run projectatomic/helloapache
+        ...
+        helloapache
+
+### Option 3: install and run
+
+You may want to download the application, review, edit the answerfile then run.
+
+1. Download the application files using `atomic install`
+
+        [sudo] atomic install projectatomic/helloapache
+
+1. Rename `answers.conf.sample`
+
+        mv answers.conf.sample answers.conf
+
+1. Edit `answers.conf`, review files if desired and run
+
+        $ [sudo] atomic run projectatomic/helloapache
+        ...
+        helloapache
+
+## Test
+Any of these approaches should create a kubernetes pod. Once its state is "Running" curl the minion it's running on.
+
+```
+$ kubectl get pod helloapache
+POD                IP                  CONTAINER(S)       IMAGE(S)           HOST                LABELS              STATUS
+helloapache        172.17.0.8          helloapache        centos/httpd       10.3.9.216/         name=helloapache   Running
+$ curl 10.3.9.216
+<bunches_of_html_goodness>
+```

--- a/tests/cached_nulecules/helloapache/artifacts/k8s/hello-apache-pod.json
+++ b/tests/cached_nulecules/helloapache/artifacts/k8s/hello-apache-pod.json
@@ -1,0 +1,25 @@
+{
+    "apiVersion": "v1beta3",
+    "kind": "Pod",
+    "metadata": {
+        "labels": {
+            "app": "helloapache"
+        },
+        "name": "helloapache"
+    },
+    "spec": {
+        "containers": [
+            {
+                "image": "$image",
+                "name": "helloapache",
+                "ports": [
+                    {
+                        "containerPort": 80,
+                        "hostPort": $hostport,
+                        "protocol": "TCP"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/.workdir/mysql-atomicapp/artifacts/kubernetes/mysql-pod.yaml
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/.workdir/mysql-atomicapp/artifacts/kubernetes/mysql-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1beta1
+id: mysql
+desiredState:
+  manifest:
+    version: v1beta1
+    id: mysql
+    containers:
+      - name: mysql
+        image: mysql
+        env:
+          - name: MYSQL_ROOT_PASSWORD
+            value: yourpassword
+        cpu: 100
+        ports:
+          - containerPort: 3306
+labels:
+  name: mysql
+kind: Pod
+

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/.workdir/mysql-atomicapp/artifacts/kubernetes/mysql-service.yaml
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/.workdir/mysql-atomicapp/artifacts/kubernetes/mysql-service.yaml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1beta1
+id: mysql
+port: 3306
+selector:
+  name: mysql
+containerPort: 3306
+labels:
+  name: mysql
+

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/.workdir/skydns/artifacts/kubernetes/skydns-replicationcontroller.yaml
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/.workdir/skydns/artifacts/kubernetes/skydns-replicationcontroller.yaml
@@ -1,0 +1,50 @@
+# From https://github.com/GoogleCloudPlatform/kubernetes/tree/master/cluster/addons/dns
+
+kind: ReplicationController
+apiVersion: v1beta1
+id: kube-dns
+namespace: default
+labels:
+  k8s-app: kube-dns
+  kubernetes.io/cluster-service: "true"
+desiredState:
+  replicas: 1
+  replicaSelector:
+    k8s-app: kube-dns
+  podTemplate:
+    labels:
+      name: kube-dns
+      k8s-app: kube-dns
+      kubernetes.io/cluster-service: "true"
+    desiredState:
+      manifest:
+        version: v1beta2
+        id: kube-dns
+        dnsPolicy: "Default"  # Don't use cluster DNS.
+        containers:
+          - name: etcd
+            image: quay.io/coreos/etcd:v2.0.3
+            command: [
+                    # entrypoint = "/etcd",
+                    "-listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001",
+                    "-initial-cluster-token=skydns-etcd",
+                    "-advertise-client-urls=http://127.0.0.1:4001",
+            ]
+          - name: kube2sky
+            image: kubernetes/kube2sky:1.1
+            command: [
+                    # entrypoint = "/kube2sky",
+                    "-domain=kube.local",
+            ]
+          - name: skydns
+            image: kubernetes/skydns:2015-03-11-001
+            command: [
+                    # entrypoint = "/skydns",
+                    "-machines=http://localhost:4001",
+                    "-addr=0.0.0.0:53",
+                    "-domain=kube.local.",
+            ]
+            ports:
+              - name: dns
+                containerPort: 53
+                protocol: UDP

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/.workdir/skydns/artifacts/kubernetes/skydns-service.yaml
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/.workdir/skydns/artifacts/kubernetes/skydns-service.yaml
@@ -1,0 +1,16 @@
+# From https://github.com/GoogleCloudPlatform/kubernetes/tree/master/cluster/addons/dns
+
+kind: Service
+apiVersion: v1beta1
+id: kube-dns
+namespace: default
+protocol: UDP
+port: 53
+portalIP: 10.254.0.10
+containerPort: 53
+labels:
+  k8s-app: kube-dns
+  name: kube-dns
+  kubernetes.io/cluster-service: "true"
+selector:
+  k8s-app: kube-dns

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/.workdir/wordpress/artifacts/kubernetes/wordpress-pod.yaml
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/.workdir/wordpress/artifacts/kubernetes/wordpress-pod.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1beta1
+id: wordpress
+desiredState:
+  manifest:
+    version: v1beta1
+    id: wordpress
+    containers:
+      - name: wordpress
+        image: goern/wordpress 
+        ports:
+          - containerPort: 80
+        env:
+          - name: WORDPRESS_DB_PASSWORD
+            # change this - must match mysql.yaml password
+            value: yourpassword
+          - name: WORDPRESS_DB_USER
+            value: root
+labels:
+  name: frontend
+kind: Pod
+

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/.workdir/wordpress/artifacts/kubernetes/wordpress-service.yaml
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/.workdir/wordpress/artifacts/kubernetes/wordpress-service.yaml
@@ -1,0 +1,9 @@
+kind: Service
+apiVersion: v1beta1
+id: frontend
+port: 80
+selector:
+  name: frontend
+containerPort: 80
+labels:
+  name: frontend

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/Dockerfile
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/Dockerfile
@@ -1,0 +1,12 @@
+FROM projectatomic/atomicapp:0.1.0
+
+MAINTAINER Christoph Görn <goern@redhat.com>
+
+LABEL io.projectatomic.nulecule.specversion 0.0.1-alpha
+
+LABEL Build docker build --rm --tag goern/wordpress-centos7-atomicapp .
+
+
+ADD /Nulecule /Dockerfile README.asciidoc gpl-3.0.txt /application-entity/
+ADD /artifacts /application-entity/artifacts
+

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/Nulecule
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/Nulecule
@@ -1,0 +1,19 @@
+---
+specversion: 0.0.2
+id: wordpress-atomicapp
+
+metadata:
+  name: Wordpress App
+  appversion: 1.1.0
+  description: Simple Wordpress atomic app. Uses remote mysql atomic app.
+graph:
+  - name: aggregated-mysql-atomicapp
+    source: docker://projectatomic/mysql-centos7-atomicapp
+  - name: aggregated-skydns-atomicapp
+    source: docker://projectatomic/skydns-atomicapp
+  - name: wordpress
+    artifacts:
+      kubernetes:
+        - file://artifacts/kubernetes/wordpress-pod.yaml
+        - file://artifacts/kubernetes/wordpress-service.yaml
+

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/README.asciidoc
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/README.asciidoc
@@ -1,0 +1,12 @@
+= Wordpress Atomicapp
+
+This is a Wordpress Atomicapp, it will use reuse MySQL and SkyDNS to
+provide a Kubernetes based Wordpress to you.
+
+== Usage
+
+`atomic run goern/wordpress-centos7-atomicapp`
+
+= Version
+
+This is version 1.1.0 of Wordpress Atomicapp.

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/artifacts/kubernetes/wordpress-pod.yaml
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/artifacts/kubernetes/wordpress-pod.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1beta1
+id: wordpress
+desiredState:
+  manifest:
+    version: v1beta1
+    id: wordpress
+    containers:
+      - name: wordpress
+        image: goern/wordpress 
+        ports:
+          - containerPort: 80
+        env:
+          - name: WORDPRESS_DB_PASSWORD
+            # change this - must match mysql.yaml password
+            value: yourpassword
+          - name: WORDPRESS_DB_USER
+            value: root
+labels:
+  name: frontend
+kind: Pod
+

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/artifacts/kubernetes/wordpress-service.yaml
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/artifacts/kubernetes/wordpress-service.yaml
@@ -1,0 +1,9 @@
+kind: Service
+apiVersion: v1beta1
+id: frontend
+port: 80
+selector:
+  name: frontend
+containerPort: 80
+labels:
+  name: frontend

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/debugout.txt
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/debugout.txt
@@ -1,0 +1,215 @@
+2015-06-01 17:55:03,429 - atomicapp.utils - DEBUG - Using working directory ./.workdir
+2015-06-01 17:55:03,430 - atomicapp.plugin - DEBUG - Loading providers from /root/src/atomicapp/atomicapp/providers
+2015-06-01 17:55:03,434 - atomicapp.nulecule_base - DEBUG - Setting app id to wordpress-atomicapp
+2015-06-01 17:55:03,434 - atomicapp.nulecule_base - DEBUG - Version check successful: specversion == 0.0.2
+2015-06-01 17:55:03,434 - atomicapp.nulecule_base - DEBUG - No artifacts for aggregated-mysql-atomicapp
+2015-06-01 17:55:03,435 - atomicapp.nulecule_base - INFO - Artifacts for aggregated-mysql-atomicapp present for these providers: 
+2015-06-01 17:55:03,435 - atomicapp.nulecule_base - DEBUG - No artifacts for aggregated-skydns-atomicapp
+2015-06-01 17:55:03,435 - atomicapp.nulecule_base - INFO - Artifacts for aggregated-skydns-atomicapp present for these providers: 
+2015-06-01 17:55:03,435 - atomicapp.nulecule_base - DEBUG - Provider: kubernetes
+2015-06-01 17:55:03,435 - atomicapp.nulecule_base - DEBUG - Artifact file://artifacts/kubernetes/wordpress-pod.yaml: OK
+2015-06-01 17:55:03,435 - atomicapp.nulecule_base - DEBUG - Artifact file://artifacts/kubernetes/wordpress-service.yaml: OK
+2015-06-01 17:55:03,435 - atomicapp.nulecule_base - INFO - Artifacts for wordpress present for these providers: kubernetes
+2015-06-01 17:55:03,435 - atomicapp.utils - DEBUG - {u'source': u'docker://projectatomic/mysql-centos7-atomicapp', u'name': u'aggregated-mysql-atomicapp'}
+2015-06-01 17:55:03,435 - atomicapp.run - WARNING - Setting image to projectatomic/mysql-centos7-atomicapp
+2015-06-01 17:55:03,435 - atomicapp.install - INFO - App name is projectatomic/mysql-centos7-atomicapp, will be populated to ./external/aggregated-mysql-atomicapp
+2015-06-01 17:55:03,435 - atomicapp.nulecule_base - DEBUG - {'namespace': 'default', 'provider': 'kubernetes'}
+2015-06-01 17:55:03,456 - atomicapp.nulecule_base - DEBUG - Output of docker images cmd: 
+Trying to pull repository docker.io/projectatomic/mysql-centos7-atomicapp ...
+d1061c6c82df: Pulling image (latest) from docker.io/projectatomic/mysql-centos7-atomicapp
+d1061c6c82df: Pulling image (latest) from docker.io/projectatomic/mysql-centos7-atomicapp, endpoint: https://registry-1.docker.io/v1/
+d1061c6c82df: Pulling dependent layers
+6941bfcbbfca: Download complete
+41459f052977: Download complete
+fd44297e2ddb: Download complete
+d6c4e4bfd4d0: Download complete
+997921258f94: Download complete
+b53519b52dd4: Download complete
+7244a82a39e9: Download complete
+0086cfa9fed4: Download complete
+8cf7e524f78c: Download complete
+5dbb1069e495: Download complete
+21176f6e9c49: Download complete
+0585ac974aee: Download complete
+7ddffd0fd07d: Download complete
+cec4eb10c857: Download complete
+4d4301d768e6: Download complete
+1103bf9b70a2: Download complete
+b500e9ff3d4f: Download complete
+390bb5cb9c81: Download complete
+a9b1cb60e8ab: Download complete
+432c3bd2a29c: Download complete
+7823c4d7f5dd: Download complete
+d1061c6c82df: Download complete
+d1061c6c82df: Download complete
+Status: Image is up to date for docker.io/projectatomic/mysql-centos7-atomicapp:latest
+2015-06-01 17:55:11,754 - atomicapp.nulecule_base - DEBUG - {'namespace': 'default', 'provider': 'kubernetes'}
+2015-06-01 17:55:11,754 - atomicapp.install - DEBUG - Creating a container with name mysql-centos7-atomicapp-IQNXhW
+284a3d0c7f2b3711f69c9ec91eb0dc9458df0b4bb50ade32f826f195a22cbef4
+2015-06-01 17:55:15,728 - atomicapp.utils - INFO - Using temporary directory /tmp/nulecule-OOPp3D
+2015-06-01 17:55:15,728 - atomicapp.install - DEBUG - ['docker', 'cp', u'mysql-centos7-atomicapp-IQNXhW:/application-entity', '/tmp/nulecule-OOPp3D']
+2015-06-01 17:55:16,876 - atomicapp.install - DEBUG - Application entity data copied to /tmp/nulecule-OOPp3D
+mysql-centos7-atomicapp-IQNXhW
+2015-06-01 17:55:19,657 - atomicapp.install - DEBUG - Nulecule path for pulled image: /tmp/nulecule-OOPp3D/application-entity/Nulecule
+2015-06-01 17:55:19,661 - atomicapp.nulecule_base - DEBUG - Setting app id to mysql-atomicapp
+2015-06-01 17:55:19,662 - atomicapp.install - DEBUG - App ID: mysql-atomicapp
+2015-06-01 17:55:19,662 - atomicapp.install - INFO - Copying app mysql-centos7-atomicapp
+2015-06-01 17:55:19,664 - atomicapp.nulecule_base - DEBUG - Version check successful: specversion == 0.0.2
+2015-06-01 17:55:19,664 - atomicapp.nulecule_base - DEBUG - Provider: kubernetes
+2015-06-01 17:55:19,664 - atomicapp.nulecule_base - DEBUG - Artifact file://artifacts/kubernetes/mysql-pod.yaml: OK
+2015-06-01 17:55:19,664 - atomicapp.nulecule_base - DEBUG - Artifact file://artifacts/kubernetes/mysql-service.yaml: OK
+2015-06-01 17:55:19,664 - atomicapp.nulecule_base - INFO - Artifacts for mysql-atomicapp present for these providers: kubernetes
+2015-06-01 17:55:19,665 - atomicapp.install - INFO - Installing dependencies for mysql-atomicapp
+2015-06-01 17:55:19,665 - atomicapp.utils - DEBUG - {u'artifacts': {u'kubernetes': [u'file://artifacts/kubernetes/mysql-pod.yaml', u'file://artifacts/kubernetes/mysql-service.yaml']}, u'name': u'mysql-atomicapp'}
+2015-06-01 17:55:19,665 - atomicapp.install - DEBUG - Component mysql-atomicapp is part of the app
+2015-06-01 17:55:19,665 - atomicapp.install - DEBUG - Values: {u'mysql-atomicapp': {}}
+2015-06-01 17:55:19,665 - atomicapp.install - DEBUG - {u'mysql-atomicapp': {}}
+2015-06-01 17:55:19,665 - atomicapp.nulecule_base - DEBUG - Data given {u'mysql-atomicapp': {}}
+2015-06-01 17:55:19,665 - atomicapp.install - DEBUG - {'general': {'namespace': 'default', 'provider': 'kubernetes'}}
+2015-06-01 17:55:19,665 - atomicapp.nulecule_base - INFO - Writing answers file template to ./external/aggregated-mysql-atomicapp/answers.conf.sample
+2015-06-01 17:55:19,666 - atomicapp.plugin - DEBUG - Loading providers from /root/src/atomicapp/atomicapp/providers
+2015-06-01 17:55:19,668 - atomicapp.nulecule_base - DEBUG - Setting app id to mysql-atomicapp
+2015-06-01 17:55:19,668 - atomicapp.nulecule_base - DEBUG - Version check successful: specversion == 0.0.2
+2015-06-01 17:55:19,668 - atomicapp.nulecule_base - DEBUG - Provider: kubernetes
+2015-06-01 17:55:19,668 - atomicapp.nulecule_base - DEBUG - Artifact file://artifacts/kubernetes/mysql-pod.yaml: OK
+2015-06-01 17:55:19,668 - atomicapp.nulecule_base - DEBUG - Artifact file://artifacts/kubernetes/mysql-service.yaml: OK
+2015-06-01 17:55:19,668 - atomicapp.nulecule_base - INFO - Artifacts for mysql-atomicapp present for these providers: kubernetes
+2015-06-01 17:55:19,669 - atomicapp.utils - DEBUG - {u'artifacts': {u'kubernetes': [u'file://artifacts/kubernetes/mysql-pod.yaml', u'file://artifacts/kubernetes/mysql-service.yaml']}, u'name': u'mysql-atomicapp'}
+2015-06-01 17:55:19,670 - atomicapp.run - DEBUG - Processing component mysql-atomicapp
+2015-06-01 17:55:19,670 - atomicapp.plugin - DEBUG - Found provider <class 'kubernetes.KubernetesProvider'>
+2015-06-01 17:55:19,670 - atomicapp.nulecule_base - DEBUG - Param namespace already in general with value default
+2015-06-01 17:55:19,670 - atomicapp.nulecule_base - DEBUG - Param provider already in general with value kubernetes
+2015-06-01 17:55:19,670 - atomicapp.run - INFO - Using provider kubernetes for component mysql-atomicapp
+2015-06-01 17:55:19,670 - atomicapp.run - DEBUG - Templating artifact ./external/aggregated-mysql-atomicapp/artifacts/kubernetes/mysql-pod.yaml
+2015-06-01 17:55:19,670 - atomicapp.nulecule_base - DEBUG - Param namespace already in general with value default
+2015-06-01 17:55:19,670 - atomicapp.nulecule_base - DEBUG - Param provider already in general with value kubernetes
+2015-06-01 17:55:19,670 - atomicapp.run - DEBUG - Config: {'namespace': 'default', 'provider': 'kubernetes'} 
+2015-06-01 17:55:19,670 - atomicapp.run - DEBUG - {'namespace': 'default', 'provider': 'kubernetes'}
+2015-06-01 17:55:19,670 - atomicapp.plugin - DEBUG - Writing artifact to ./.workdir/mysql-atomicapp/artifacts/kubernetes/mysql-pod.yaml
+2015-06-01 17:55:19,670 - atomicapp.run - DEBUG - Templating artifact ./external/aggregated-mysql-atomicapp/artifacts/kubernetes/mysql-service.yaml
+2015-06-01 17:55:19,670 - atomicapp.nulecule_base - DEBUG - Param namespace already in general with value default
+2015-06-01 17:55:19,670 - atomicapp.nulecule_base - DEBUG - Param provider already in general with value kubernetes
+2015-06-01 17:55:19,670 - atomicapp.run - DEBUG - Config: {'namespace': 'default', 'provider': 'kubernetes'} 
+2015-06-01 17:55:19,670 - atomicapp.run - DEBUG - {'namespace': 'default', 'provider': 'kubernetes'}
+2015-06-01 17:55:19,670 - atomicapp.plugin - DEBUG - Writing artifact to ./.workdir/mysql-atomicapp/artifacts/kubernetes/mysql-service.yaml
+2015-06-01 17:55:19,671 - kubernetes - DEBUG - Given config: {'namespace': 'default', 'provider': 'kubernetes'}
+2015-06-01 17:55:19,671 - kubernetes - INFO - Using namespace default
+2015-06-01 17:55:19,671 - kubernetes - INFO - Deploying to Kubernetes
+2015-06-01 17:55:19,671 - kubernetes - DEBUG - ./.workdir/mysql-atomicapp/artifacts/kubernetes/mysql-pod.yaml
+2015-06-01 17:55:19,673 - kubernetes - DEBUG - ./.workdir/mysql-atomicapp/artifacts/kubernetes/mysql-service.yaml
+2015-06-01 17:55:19,675 - kubernetes - INFO - DRY-RUN: /usr/bin/kubectl create -f ./.workdir/mysql-atomicapp/artifacts/kubernetes/mysql-service.yaml --namespace=default
+2015-06-01 17:55:19,675 - kubernetes - INFO - DRY-RUN: /usr/bin/kubectl create -f ./.workdir/mysql-atomicapp/artifacts/kubernetes/mysql-pod.yaml --namespace=default
+2015-06-01 17:55:19,675 - atomicapp.utils - DEBUG - {u'source': u'docker://projectatomic/skydns-atomicapp', u'name': u'aggregated-skydns-atomicapp'}
+2015-06-01 17:55:19,675 - atomicapp.run - WARNING - Setting image to projectatomic/skydns-atomicapp
+2015-06-01 17:55:19,675 - atomicapp.install - INFO - App name is projectatomic/skydns-atomicapp, will be populated to ./external/aggregated-skydns-atomicapp
+2015-06-01 17:55:19,675 - atomicapp.nulecule_base - DEBUG - {'namespace': 'default', 'provider': 'kubernetes'}
+2015-06-01 17:55:19,693 - atomicapp.nulecule_base - DEBUG - Output of docker images cmd: 
+Trying to pull repository docker.io/projectatomic/skydns-atomicapp ...
+4174891b5c83: Pulling image (latest) from docker.io/projectatomic/skydns-atomicapp
+4174891b5c83: Pulling image (latest) from docker.io/projectatomic/skydns-atomicapp, endpoint: https://registry-1.docker.io/v1/
+4174891b5c83: Pulling dependent layers
+6941bfcbbfca: Download complete
+41459f052977: Download complete
+fd44297e2ddb: Download complete
+d6c4e4bfd4d0: Download complete
+997921258f94: Download complete
+b53519b52dd4: Download complete
+7244a82a39e9: Download complete
+0086cfa9fed4: Download complete
+8cf7e524f78c: Download complete
+5dbb1069e495: Download complete
+21176f6e9c49: Download complete
+0585ac974aee: Download complete
+7ddffd0fd07d: Download complete
+cec4eb10c857: Download complete
+4d4301d768e6: Download complete
+1103bf9b70a2: Download complete
+b500e9ff3d4f: Download complete
+9e93adcb96c2: Download complete
+e6396b0b694c: Download complete
+41be5473655a: Download complete
+8810723baa3c: Download complete
+4174891b5c83: Download complete
+4174891b5c83: Download complete
+Status: Image is up to date for docker.io/projectatomic/skydns-atomicapp:latest
+2015-06-01 17:55:21,093 - atomicapp.nulecule_base - DEBUG - {'namespace': 'default', 'provider': 'kubernetes'}
+2015-06-01 17:55:21,094 - atomicapp.install - DEBUG - Creating a container with name skydns-atomicapp-FygeYO
+1c16cc38e0c10ea987bb01571f0e4a3ed1dd7b252d67cf357851a85fc6635d16
+2015-06-01 17:55:25,667 - atomicapp.utils - INFO - Using temporary directory /tmp/nulecule-I2iLNZ
+2015-06-01 17:55:25,667 - atomicapp.install - DEBUG - ['docker', 'cp', u'skydns-atomicapp-FygeYO:/application-entity', '/tmp/nulecule-I2iLNZ']
+2015-06-01 17:55:27,229 - atomicapp.install - DEBUG - Application entity data copied to /tmp/nulecule-I2iLNZ
+skydns-atomicapp-FygeYO
+2015-06-01 17:55:31,199 - atomicapp.install - DEBUG - Nulecule path for pulled image: /tmp/nulecule-I2iLNZ/application-entity/Nulecule
+2015-06-01 17:55:31,206 - atomicapp.nulecule_base - DEBUG - Setting app id to skydns-atomicapp
+2015-06-01 17:55:31,206 - atomicapp.install - DEBUG - App ID: skydns-atomicapp
+2015-06-01 17:55:31,206 - atomicapp.install - INFO - Copying app skydns-atomicapp
+2015-06-01 17:55:31,208 - atomicapp.nulecule_base - DEBUG - Version check successful: specversion == 0.0.2
+2015-06-01 17:55:31,208 - atomicapp.nulecule_base - DEBUG - Provider: kubernetes
+2015-06-01 17:55:31,208 - atomicapp.nulecule_base - DEBUG - Artifact file://artifacts/kubernetes/skydns-replicationcontroller.yaml: OK
+2015-06-01 17:55:31,208 - atomicapp.nulecule_base - DEBUG - Artifact file://artifacts/kubernetes/skydns-service.yaml: OK
+2015-06-01 17:55:31,208 - atomicapp.nulecule_base - INFO - Artifacts for skydns present for these providers: kubernetes
+2015-06-01 17:55:31,208 - atomicapp.install - INFO - Installing dependencies for skydns-atomicapp
+2015-06-01 17:55:31,208 - atomicapp.utils - DEBUG - {u'artifacts': {u'kubernetes': [u'file://artifacts/kubernetes/skydns-replicationcontroller.yaml', u'file://artifacts/kubernetes/skydns-service.yaml']}, u'params': [{u'default': u'kube.local', u'name': u'dns_domain', u'description': u'Internal DNS domain name. This domain must not be used in your network. Services will be discoverable under <service-name>.<namespace>.<domainname>, e.g. myservice.default.kube.local\n'}, {u'default': u'10.254.0.10', u'name': u'dns_server', u'description': u'IP address of the DNS server. Kubernetes will create a pod with several containers, serving as the DNS server and expose it under this IP address. The IP address must be from the range specified as kube_service_addresses above. And this is the IP address you should use as address of the DNS server in your containers.\n'}], u'name': u'skydns'}
+2015-06-01 17:55:31,208 - atomicapp.install - DEBUG - Component skydns is part of the app
+2015-06-01 17:55:31,208 - atomicapp.install - DEBUG - Values: {u'skydns': {u'dns_server': u'10.254.0.10', u'dns_domain': u'kube.local'}}
+2015-06-01 17:55:31,208 - atomicapp.install - DEBUG - {u'skydns': {u'dns_server': u'10.254.0.10', u'dns_domain': u'kube.local'}}
+2015-06-01 17:55:31,208 - atomicapp.nulecule_base - DEBUG - Data given {u'skydns': {u'dns_server': u'10.254.0.10', u'dns_domain': u'kube.local'}}
+2015-06-01 17:55:31,209 - atomicapp.install - DEBUG - {u'skydns': {u'dns_server': u'10.254.0.10', u'dns_domain': u'kube.local'}, 'general': {'namespace': 'default', 'provider': 'kubernetes'}}
+2015-06-01 17:55:31,209 - atomicapp.nulecule_base - INFO - Writing answers file template to ./external/aggregated-skydns-atomicapp/answers.conf.sample
+2015-06-01 17:55:31,210 - atomicapp.plugin - DEBUG - Loading providers from /root/src/atomicapp/atomicapp/providers
+2015-06-01 17:55:31,214 - atomicapp.nulecule_base - DEBUG - Setting app id to skydns-atomicapp
+2015-06-01 17:55:31,214 - atomicapp.nulecule_base - DEBUG - Version check successful: specversion == 0.0.2
+2015-06-01 17:55:31,214 - atomicapp.nulecule_base - DEBUG - Provider: kubernetes
+2015-06-01 17:55:31,214 - atomicapp.nulecule_base - DEBUG - Artifact file://artifacts/kubernetes/skydns-replicationcontroller.yaml: OK
+2015-06-01 17:55:31,214 - atomicapp.nulecule_base - DEBUG - Artifact file://artifacts/kubernetes/skydns-service.yaml: OK
+2015-06-01 17:55:31,214 - atomicapp.nulecule_base - INFO - Artifacts for skydns present for these providers: kubernetes
+2015-06-01 17:55:31,214 - atomicapp.utils - DEBUG - {u'artifacts': {u'kubernetes': [u'file://artifacts/kubernetes/skydns-replicationcontroller.yaml', u'file://artifacts/kubernetes/skydns-service.yaml']}, u'params': [{u'default': u'kube.local', u'name': u'dns_domain', u'description': u'Internal DNS domain name. This domain must not be used in your network. Services will be discoverable under <service-name>.<namespace>.<domainname>, e.g. myservice.default.kube.local\n'}, {u'default': u'10.254.0.10', u'name': u'dns_server', u'description': u'IP address of the DNS server. Kubernetes will create a pod with several containers, serving as the DNS server and expose it under this IP address. The IP address must be from the range specified as kube_service_addresses above. And this is the IP address you should use as address of the DNS server in your containers.\n'}], u'name': u'skydns'}
+2015-06-01 17:55:31,214 - atomicapp.run - DEBUG - Processing component skydns
+2015-06-01 17:55:31,214 - atomicapp.plugin - DEBUG - Found provider <class 'kubernetes.KubernetesProvider'>
+2015-06-01 17:55:31,214 - atomicapp.nulecule_base - DEBUG - Param namespace already in general with value default
+2015-06-01 17:55:31,214 - atomicapp.nulecule_base - DEBUG - Param provider already in general with value kubernetes
+2015-06-01 17:55:31,215 - atomicapp.run - INFO - Using provider kubernetes for component skydns
+2015-06-01 17:55:31,215 - atomicapp.run - DEBUG - Templating artifact ./external/aggregated-skydns-atomicapp/artifacts/kubernetes/skydns-replicationcontroller.yaml
+2015-06-01 17:55:31,215 - atomicapp.nulecule_base - DEBUG - Param namespace already in general with value default
+2015-06-01 17:55:31,215 - atomicapp.nulecule_base - DEBUG - Param provider already in general with value kubernetes
+2015-06-01 17:55:31,215 - atomicapp.run - DEBUG - Config: {u'dns_server': u'10.254.0.10', 'namespace': 'default', u'dns_domain': u'kube.local', 'provider': 'kubernetes'} 
+2015-06-01 17:55:31,215 - atomicapp.run - DEBUG - {u'dns_server': u'10.254.0.10', 'namespace': 'default', u'dns_domain': u'kube.local', 'provider': 'kubernetes'}
+2015-06-01 17:55:31,215 - atomicapp.plugin - DEBUG - Writing artifact to ./.workdir/skydns/artifacts/kubernetes/skydns-replicationcontroller.yaml
+2015-06-01 17:55:31,215 - atomicapp.run - DEBUG - Templating artifact ./external/aggregated-skydns-atomicapp/artifacts/kubernetes/skydns-service.yaml
+2015-06-01 17:55:31,215 - atomicapp.nulecule_base - DEBUG - Param namespace already in general with value default
+2015-06-01 17:55:31,215 - atomicapp.nulecule_base - DEBUG - Param provider already in general with value kubernetes
+2015-06-01 17:55:31,215 - atomicapp.run - DEBUG - Config: {u'dns_server': u'10.254.0.10', 'namespace': 'default', u'dns_domain': u'kube.local', 'provider': 'kubernetes'} 
+2015-06-01 17:55:31,215 - atomicapp.run - DEBUG - {u'dns_server': u'10.254.0.10', 'namespace': 'default', u'dns_domain': u'kube.local', 'provider': 'kubernetes'}
+2015-06-01 17:55:31,215 - atomicapp.plugin - DEBUG - Writing artifact to ./.workdir/skydns/artifacts/kubernetes/skydns-service.yaml
+2015-06-01 17:55:31,215 - kubernetes - DEBUG - Given config: {u'dns_server': u'10.254.0.10', 'namespace': 'default', u'dns_domain': u'kube.local', 'provider': 'kubernetes'}
+2015-06-01 17:55:31,215 - kubernetes - INFO - Using namespace default
+2015-06-01 17:55:31,216 - kubernetes - INFO - Deploying to Kubernetes
+2015-06-01 17:55:31,216 - kubernetes - DEBUG - ./.workdir/skydns/artifacts/kubernetes/skydns-replicationcontroller.yaml
+2015-06-01 17:55:31,223 - kubernetes - DEBUG - ./.workdir/skydns/artifacts/kubernetes/skydns-service.yaml
+2015-06-01 17:55:31,226 - kubernetes - INFO - DRY-RUN: /usr/bin/kubectl create -f ./.workdir/skydns/artifacts/kubernetes/skydns-service.yaml --namespace=default
+2015-06-01 17:55:31,226 - kubernetes - INFO - DRY-RUN: /usr/bin/kubectl create -f ./.workdir/skydns/artifacts/kubernetes/skydns-replicationcontroller.yaml --namespace=default
+2015-06-01 17:55:31,226 - atomicapp.utils - DEBUG - {u'artifacts': {u'kubernetes': [u'file://artifacts/kubernetes/wordpress-pod.yaml', u'file://artifacts/kubernetes/wordpress-service.yaml']}, u'name': u'wordpress'}
+2015-06-01 17:55:31,226 - atomicapp.run - DEBUG - Processing component wordpress
+2015-06-01 17:55:31,226 - atomicapp.plugin - DEBUG - Found provider <class 'kubernetes.KubernetesProvider'>
+2015-06-01 17:55:31,226 - atomicapp.nulecule_base - DEBUG - Param namespace already in general with value default
+2015-06-01 17:55:31,226 - atomicapp.nulecule_base - DEBUG - Param provider already in general with value kubernetes
+2015-06-01 17:55:31,226 - atomicapp.run - INFO - Using provider kubernetes for component wordpress
+2015-06-01 17:55:31,226 - atomicapp.run - DEBUG - Templating artifact .//artifacts/kubernetes/wordpress-pod.yaml
+2015-06-01 17:55:31,227 - atomicapp.nulecule_base - DEBUG - Param namespace already in general with value default
+2015-06-01 17:55:31,227 - atomicapp.nulecule_base - DEBUG - Param provider already in general with value kubernetes
+2015-06-01 17:55:31,227 - atomicapp.run - DEBUG - Config: {'namespace': 'default', 'provider': 'kubernetes'} 
+2015-06-01 17:55:31,227 - atomicapp.run - DEBUG - {'namespace': 'default', 'provider': 'kubernetes'}
+2015-06-01 17:55:31,227 - atomicapp.plugin - DEBUG - Writing artifact to ./.workdir/wordpress/artifacts/kubernetes/wordpress-pod.yaml
+2015-06-01 17:55:31,227 - atomicapp.run - DEBUG - Templating artifact .//artifacts/kubernetes/wordpress-service.yaml
+2015-06-01 17:55:31,227 - atomicapp.nulecule_base - DEBUG - Param namespace already in general with value default
+2015-06-01 17:55:31,227 - atomicapp.nulecule_base - DEBUG - Param provider already in general with value kubernetes
+2015-06-01 17:55:31,227 - atomicapp.run - DEBUG - Config: {'namespace': 'default', 'provider': 'kubernetes'} 
+2015-06-01 17:55:31,227 - atomicapp.run - DEBUG - {'namespace': 'default', 'provider': 'kubernetes'}
+2015-06-01 17:55:31,227 - atomicapp.plugin - DEBUG - Writing artifact to ./.workdir/wordpress/artifacts/kubernetes/wordpress-service.yaml
+2015-06-01 17:55:31,227 - kubernetes - DEBUG - Given config: {'namespace': 'default', 'provider': 'kubernetes'}
+2015-06-01 17:55:31,227 - kubernetes - INFO - Using namespace default
+2015-06-01 17:55:31,227 - kubernetes - INFO - Deploying to Kubernetes
+2015-06-01 17:55:31,227 - kubernetes - DEBUG - ./.workdir/wordpress/artifacts/kubernetes/wordpress-pod.yaml
+2015-06-01 17:55:31,230 - kubernetes - DEBUG - ./.workdir/wordpress/artifacts/kubernetes/wordpress-service.yaml
+2015-06-01 17:55:31,232 - kubernetes - INFO - DRY-RUN: /usr/bin/kubectl create -f ./.workdir/wordpress/artifacts/kubernetes/wordpress-service.yaml --namespace=default
+2015-06-01 17:55:31,232 - kubernetes - INFO - DRY-RUN: /usr/bin/kubectl create -f ./.workdir/wordpress/artifacts/kubernetes/wordpress-pod.yaml --namespace=default

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-mysql-atomicapp/Dockerfile
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-mysql-atomicapp/Dockerfile
@@ -1,0 +1,11 @@
+FROM projectatomic/atomicapp:0.1.0
+
+MAINTAINER Christoph Görn <goern@redhat.com>
+
+LABEL io.projectatomic.nulecule.specversion 0.0.1-alpha
+
+LABEL Build docker build --rm --tag goern/mysql-centos7-atomicapp .
+
+
+ADD /Nulecule /Dockerfile README.asciidoc gpl-3.0.txt /application-entity/
+ADD /artifacts /application-entity/artifacts

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-mysql-atomicapp/Nulecule
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-mysql-atomicapp/Nulecule
@@ -1,0 +1,15 @@
+---
+specversion: 0.0.2
+id: mysql-atomicapp
+
+metadata:
+  name: MySQL Atomicapp
+  appversion: 1.0.0
+  description: This is MySQL
+graph:
+  - name: mysql-atomicapp
+    artifacts:
+      kubernetes:
+        - file://artifacts/kubernetes/mysql-pod.yaml
+        - file://artifacts/kubernetes/mysql-service.yaml
+

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-mysql-atomicapp/answers.conf.sample
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-mysql-atomicapp/answers.conf.sample
@@ -1,0 +1,3 @@
+[general]
+namespace = default
+provider = kubernetes

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-mysql-atomicapp/artifacts/kubernetes/mysql-pod.yaml
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-mysql-atomicapp/artifacts/kubernetes/mysql-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1beta1
+id: mysql
+desiredState:
+  manifest:
+    version: v1beta1
+    id: mysql
+    containers:
+      - name: mysql
+        image: mysql
+        env:
+          - name: MYSQL_ROOT_PASSWORD
+            value: yourpassword
+        cpu: 100
+        ports:
+          - containerPort: 3306
+labels:
+  name: mysql
+kind: Pod
+

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-mysql-atomicapp/artifacts/kubernetes/mysql-service.yaml
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-mysql-atomicapp/artifacts/kubernetes/mysql-service.yaml
@@ -1,0 +1,10 @@
+kind: Service
+apiVersion: v1beta1
+id: mysql
+port: 3306
+selector:
+  name: mysql
+containerPort: 3306
+labels:
+  name: mysql
+

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-mysql-atomicapp/gpl-3.0.txt
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-mysql-atomicapp/gpl-3.0.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-skydns-atomicapp/Nulecule
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-skydns-atomicapp/Nulecule
@@ -1,0 +1,32 @@
+---
+specversion: 0.0.2
+id: skydns-atomicapp
+metadata:
+  name: SkyDNS
+  appversion: 2015-03-11-001
+  description: >
+    This is a nulecule that will get you the container components you need
+    to dev on nulecule apps
+graph:
+  - name: skydns
+    params:
+      - name: dns_domain
+        description: >
+          Internal DNS domain name.
+          This domain must not be used in your network. Services will be discoverable
+          under <service-name>.<namespace>.<domainname>, e.g.
+          myservice.default.kube.local
+        default: kube.local
+      - name: dns_server
+        description: >
+          IP address of the DNS server.
+          Kubernetes will create a pod with several containers, serving as the DNS
+          server and expose it under this IP address. The IP address must be from
+          the range specified as kube_service_addresses above.
+          And this is the IP address you should use as address of the DNS server
+          in your containers.
+        default: 10.254.0.10
+    artifacts:
+      kubernetes:
+        - file://artifacts/kubernetes/skydns-replicationcontroller.yaml
+        - file://artifacts/kubernetes/skydns-service.yaml

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-skydns-atomicapp/answers.conf.sample
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-skydns-atomicapp/answers.conf.sample
@@ -1,0 +1,6 @@
+[skydns]
+dns_server = 10.254.0.10
+dns_domain = kube.local
+[general]
+namespace = default
+provider = kubernetes

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-skydns-atomicapp/artifacts/kubernetes/skydns-replicationcontroller.yaml
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-skydns-atomicapp/artifacts/kubernetes/skydns-replicationcontroller.yaml
@@ -1,0 +1,50 @@
+# From https://github.com/GoogleCloudPlatform/kubernetes/tree/master/cluster/addons/dns
+
+kind: ReplicationController
+apiVersion: v1beta1
+id: kube-dns
+namespace: default
+labels:
+  k8s-app: kube-dns
+  kubernetes.io/cluster-service: "true"
+desiredState:
+  replicas: 1
+  replicaSelector:
+    k8s-app: kube-dns
+  podTemplate:
+    labels:
+      name: kube-dns
+      k8s-app: kube-dns
+      kubernetes.io/cluster-service: "true"
+    desiredState:
+      manifest:
+        version: v1beta2
+        id: kube-dns
+        dnsPolicy: "Default"  # Don't use cluster DNS.
+        containers:
+          - name: etcd
+            image: quay.io/coreos/etcd:v2.0.3
+            command: [
+                    # entrypoint = "/etcd",
+                    "-listen-client-urls=http://0.0.0.0:2379,http://0.0.0.0:4001",
+                    "-initial-cluster-token=skydns-etcd",
+                    "-advertise-client-urls=http://127.0.0.1:4001",
+            ]
+          - name: kube2sky
+            image: kubernetes/kube2sky:1.1
+            command: [
+                    # entrypoint = "/kube2sky",
+                    "-domain=$dns_domain",
+            ]
+          - name: skydns
+            image: kubernetes/skydns:2015-03-11-001
+            command: [
+                    # entrypoint = "/skydns",
+                    "-machines=http://localhost:4001",
+                    "-addr=0.0.0.0:53",
+                    "-domain=$dns_domain.",
+            ]
+            ports:
+              - name: dns
+                containerPort: 53
+                protocol: UDP

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-skydns-atomicapp/artifacts/kubernetes/skydns-service.yaml
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/external/aggregated-skydns-atomicapp/artifacts/kubernetes/skydns-service.yaml
@@ -1,0 +1,16 @@
+# From https://github.com/GoogleCloudPlatform/kubernetes/tree/master/cluster/addons/dns
+
+kind: Service
+apiVersion: v1beta1
+id: kube-dns
+namespace: default
+protocol: UDP
+port: 53
+portalIP: $dns_server
+containerPort: 53
+labels:
+  k8s-app: kube-dns
+  name: kube-dns
+  kubernetes.io/cluster-service: "true"
+selector:
+  k8s-app: kube-dns

--- a/tests/cached_nulecules/wordpress-centos7-atomicapp/gpl-3.0.txt
+++ b/tests/cached_nulecules/wordpress-centos7-atomicapp/gpl-3.0.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/tests/test_cached_nulecules.sh
+++ b/tests/test_cached_nulecules.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+let failures=0
+
+for testdir in `ls cached_nulecules`; do
+  pushd cached_nulecules/$testdir
+  #atomicapp --verbose --dry-run run ./
+  echo TESTING $testdir
+  if ../../../atomicapp/cli/main.py --verbose --dry-run run ./; then
+      echo success!
+  else
+      echo FAILED
+      let failures+=1
+  fi
+  popd
+done
+
+if [ "$failures" -eq "0" ]; then
+    echo No failures
+    exit 0
+else
+    echo $failures failures
+    exit 1
+fi


### PR DESCRIPTION
These two tests take advantage of the --dry-run option as well as the caching of
previously extracted Docker image content.  If any element of this caching
behavior is changed, these test will likely need to be recreated.

The two tests Nulecules are borrowed from the nulecule spec examples here:

https://github.com/projectatomic/nulecule/tree/master/examples

I created this test content by doing a dry run on a system actually running
Docker, then extracting the "external" directory.
